### PR TITLE
Configure sense for each direction (UP and DOWN)

### DIFF
--- a/CapacitiveSensor.cpp
+++ b/CapacitiveSensor.cpp
@@ -77,7 +77,7 @@ CapacitiveSensor::CapacitiveSensor(uint8_t sendPin, uint8_t receivePin)
 // Public Methods //////////////////////////////////////////////////////////////
 // Functions available in Wiring sketches, this library, and other libraries
 
-long CapacitiveSensor::capacitiveSensor(uint8_t samples)
+long CapacitiveSensor::capacitiveSensor(uint8_t samples, char dir)
 {
 	total = 0;
 	if (samples == 0) return 0;
@@ -85,7 +85,7 @@ long CapacitiveSensor::capacitiveSensor(uint8_t samples)
 
 
 	for (uint8_t i = 0; i < samples; i++) {    // loop for samples parameter - simple lowpass filter
-		if (SenseOneCycle() < 0)  return -2;   // variable over timeout
+		if (SenseOneCycle(dir) < 0)  return -2;   // variable over timeout
 }
 
 		// only calibrate if time is greater than CS_AutocaL_Millis and total is less than 10% of baseline
@@ -122,14 +122,14 @@ long CapacitiveSensor::capacitiveSensor(uint8_t samples)
 
 }
 
-long CapacitiveSensor::capacitiveSensorRaw(uint8_t samples)
+long CapacitiveSensor::capacitiveSensorRaw(uint8_t samples, char dir)
 {
 	total = 0;
 	if (samples == 0) return 0;
 	if (error < 0) return -1;                  // bad pin - this appears not to work
 
 	for (uint8_t i = 0; i < samples; i++) {    // loop for samples parameter - simple lowpass filter
-		if (SenseOneCycle() < 0)  return -2;   // variable over timeout
+		if (SenseOneCycle(dir) < 0)  return -2;   // variable over timeout
 	}
 
 	return total;
@@ -151,53 +151,58 @@ void CapacitiveSensor::set_CS_Timeout_Millis(unsigned long timeout_millis){
 // Private Methods /////////////////////////////////////////////////////////////
 // Functions only available to other functions in this library
 
-int CapacitiveSensor::SenseOneCycle(void)
+int CapacitiveSensor::SenseOneCycle(char dir)
 {
+  if (dir & UP){
     noInterrupts();
-	DIRECT_WRITE_LOW(sReg, sBit);	// sendPin Register low
-	DIRECT_MODE_INPUT(rReg, rBit);	// receivePin to input (pullups are off)
-	DIRECT_MODE_OUTPUT(rReg, rBit); // receivePin to OUTPUT
-	DIRECT_WRITE_LOW(rReg, rBit);	// pin is now LOW AND OUTPUT
-	delayMicroseconds(10);
-	DIRECT_MODE_INPUT(rReg, rBit);	// receivePin to input (pullups are off)
-	DIRECT_WRITE_HIGH(sReg, sBit);	// sendPin High
-    interrupts();
+  	DIRECT_WRITE_LOW(sReg, sBit);	// sendPin Register low
+  	DIRECT_MODE_INPUT(rReg, rBit);	// receivePin to input (pullups are off)
+  	DIRECT_MODE_OUTPUT(rReg, rBit); // receivePin to OUTPUT
+  	DIRECT_WRITE_LOW(rReg, rBit);	// pin is now LOW AND OUTPUT
+  	delayMicroseconds(10);
+  	DIRECT_MODE_INPUT(rReg, rBit);	// receivePin to input (pullups are off)
+  	DIRECT_WRITE_HIGH(sReg, sBit);	// sendPin High
+      interrupts();
+  
+  	while ( !DIRECT_READ(rReg, rBit) && (total < CS_Timeout_Millis) ) {  // while receive pin is LOW AND total is positive value
+  		total++;
+  	}
+  	//Serial.print("SenseOneCycle(UP): ");	Serial.println(total);
+  
+      
+  	if (total > CS_Timeout_Millis) {
+  		return -2;         //  total variable over timeout
+  	}
+  }
 
-	while ( !DIRECT_READ(rReg, rBit) && (total < CS_Timeout_Millis) ) {  // while receive pin is LOW AND total is positive value
-		total++;
-	}
-	//Serial.print("SenseOneCycle(1): ");
-	//Serial.println(total);
-
-	if (total > CS_Timeout_Millis) {
-		return -2;         //  total variable over timeout
-	}
-
-	// set receive pin HIGH briefly to charge up fully - because the while loop above will exit when pin is ~ 2.5V
-    noInterrupts();
-	DIRECT_WRITE_HIGH(rReg, rBit);
-	DIRECT_MODE_OUTPUT(rReg, rBit);  // receivePin to OUTPUT - pin is now HIGH AND OUTPUT
-	DIRECT_WRITE_HIGH(rReg, rBit);
-	DIRECT_MODE_INPUT(rReg, rBit);	// receivePin to INPUT (pullup is off)
-	DIRECT_WRITE_LOW(sReg, sBit);	// sendPin LOW
-    interrupts();
-
-#ifdef FIVE_VOLT_TOLERANCE_WORKAROUND
-	DIRECT_MODE_OUTPUT(rReg, rBit);
-	DIRECT_WRITE_LOW(rReg, rBit);
-	delayMicroseconds(10);
-	DIRECT_MODE_INPUT(rReg, rBit);	// receivePin to INPUT (pullup is off)
-#else
-	while ( DIRECT_READ(rReg, rBit) && (total < CS_Timeout_Millis) ) {  // while receive pin is HIGH  AND total is less than timeout
-		total++;
-	}
-#endif
-	//Serial.print("SenseOneCycle(2): ");
-	//Serial.println(total);
-
-	if (total >= CS_Timeout_Millis) {
-		return -2;     // total variable over timeout
-	} else {
-		return 1;
-	}
+  if (dir & DOWN){
+    unsigned long total1 = total;
+  	// set receive pin HIGH briefly to charge up fully - because the while loop above will exit when pin is ~ 2.5V
+      noInterrupts();
+  	DIRECT_WRITE_HIGH(rReg, rBit);
+  	DIRECT_MODE_OUTPUT(rReg, rBit);  // receivePin to OUTPUT - pin is now HIGH AND OUTPUT
+  	DIRECT_WRITE_HIGH(rReg, rBit);
+  	DIRECT_MODE_INPUT(rReg, rBit);	// receivePin to INPUT (pullup is off)
+  	DIRECT_WRITE_LOW(sReg, sBit);	// sendPin LOW
+      interrupts();
+  
+  #ifdef FIVE_VOLT_TOLERANCE_WORKAROUND
+  	DIRECT_MODE_OUTPUT(rReg, rBit);
+  	DIRECT_WRITE_LOW(rReg, rBit);
+  	delayMicroseconds(10);
+  	DIRECT_MODE_INPUT(rReg, rBit);	// receivePin to INPUT (pullup is off)
+  #else
+  	while ( DIRECT_READ(rReg, rBit) && (total < CS_Timeout_Millis) ) {  // while receive pin is HIGH  AND total is less than timeout
+  		total++;
+  	}
+  #endif
+  	//Serial.print("SenseOneCycle(DN): ");	Serial.println(total - total1);
+  
+  	if (total >= CS_Timeout_Millis) {
+  		return -2;     // total variable over timeout
+  	} else {
+  		return 1;
+  	}
+  }else
+    return 1;
 }

--- a/CapacitiveSensor.h
+++ b/CapacitiveSensor.h
@@ -214,6 +214,11 @@ void directWriteHigh(volatile IO_REG_TYPE *base, IO_REG_TYPE pin)
 #define FIVE_VOLT_TOLERANCE_WORKAROUND
 #endif
 
+
+#define UP 1
+#define DOWN 2
+#define BOTH (UP | DOWN)
+
 // library interface description
 class CapacitiveSensor
 {
@@ -221,8 +226,8 @@ class CapacitiveSensor
   public:
   // methods
 	CapacitiveSensor(uint8_t sendPin, uint8_t receivePin);
-	long capacitiveSensorRaw(uint8_t samples);
-	long capacitiveSensor(uint8_t samples);
+	long capacitiveSensorRaw(uint8_t samples, char dir = BOTH);
+	long capacitiveSensor(uint8_t samples, char dir = BOTH);
 	void set_CS_Timeout_Millis(unsigned long timeout_millis);
 	void reset_CS_AutoCal();
 	void set_CS_AutocaL_Millis(unsigned long autoCal_millis);
@@ -241,7 +246,7 @@ class CapacitiveSensor
 	IO_REG_TYPE rBit;    // receive pin's ports and bitmask
 	volatile IO_REG_TYPE *rReg;
   // methods
-	int SenseOneCycle(void);
+	int SenseOneCycle(char dir);
 };
 
 #endif


### PR DESCRIPTION
I noticed that depending on environment (surrounding electric fields?) one sensing direction has more sensitiveness  that other.
By direction I mean either detection state change from 0 to 1 (UP), or from 1 to 0 (DOWN).

Currently both direction are measured and results are added. I add option to measure it in any direction or both (with keeping backward compatibility).
