### PR TITLE
Add support for Arduino Nano 33 BLE Sense

### DIFF
--- a/CapacitiveSensor.h
+++ b/CapacitiveSensor.h
@@ -248,6 +248,16 @@ void directModeOutput(IO_REG_TYPE pin)
 #define DIRECT_WRITE_HIGH(base, mask)   ((*((base)+6)) = (mask)) /// OUTSET
 
 #elif defined(ARDUINO_NRF52_ADAFRUIT) || defined(ARDUINO_ARCH_NRF52840)
+
+/* 
+Required for the Arduino Nano 33 BLE Sense to satisfy the compiler
+as build.f_cpu is not defined in the boards.txt file.
+The concept of F_CPU doesn't fully apply as mbed RTOS is used which uses preemption.
+*/
+#if defined(ARDUINO_ARCH_NRF52840) && !defined(F_CPU)
+#define F_CPU 64000000L
+#endif
+
 #define PIN_TO_BASEREG(pin)             (0)
 #define PIN_TO_BITMASK(pin)             digitalPinToPinName(pin)
 #define IO_REG_TYPE uint32_t

--- a/CapacitiveSensor.h
+++ b/CapacitiveSensor.h
@@ -247,7 +247,7 @@ void directModeOutput(IO_REG_TYPE pin)
 #define DIRECT_WRITE_LOW(base, mask)    ((*((base)+5)) = (mask)) // OUTCLR
 #define DIRECT_WRITE_HIGH(base, mask)   ((*((base)+6)) = (mask)) /// OUTSET
 
-#elif defined(ARDUINO_NRF52_ADAFRUIT)
+#elif defined(ARDUINO_NRF52_ADAFRUIT) || defined(ARDUINO_ARCH_NRF52840)
 #define PIN_TO_BASEREG(pin)             (0)
 #define PIN_TO_BITMASK(pin)             digitalPinToPinName(pin)
 #define IO_REG_TYPE uint32_t


### PR DESCRIPTION
This PR adds support for Arduino Nano 33 BLE Sense and fixes https://github.com/PaulStoffregen/CapacitiveSensor/issues/37

@PaulStoffregen I had to put a `F_CPU` as a pre-compiler directive which is not ideal but the Arduino Nano 33 BLE Sense core doesn't expose it in the boards.txt file as it wouldn't fully make sense to do that considering that the core is built on the Mbed RTOS. What do you think?