### PR TITLE
Update CapacitiveSensor.cpp

### DIFF
--- a/CapacitiveSensor.cpp
+++ b/CapacitiveSensor.cpp
@@ -90,8 +90,8 @@ long CapacitiveSensor::capacitiveSensor(uint8_t samples)
 
 		// only calibrate if time is greater than CS_AutocaL_Millis and total is less than 10% of baseline
 		// this is an attempt to keep from calibrating when the sensor is seeing a "touched" signal
-
-		if ( (millis() - lastCal > CS_AutocaL_Millis) && abs(total  - leastTotal) < (int)(.10 * (float)leastTotal) ) {
+		unsigned long diff = (total > leastTotal) ? total - leastTotal : leastTotal - total;
+		if ( (millis() - lastCal > CS_AutocaL_Millis) && diff < (int)(.10 * (float)leastTotal) ) {
 
 			// Serial.println();               // debugging
 			// Serial.println("auto-calibrate");


### PR DESCRIPTION
removed usage of abs() function as it used unsigned long argument which isnt allowed by esp framework. It now compiles for esp8266.